### PR TITLE
add encodings fn, zstd support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-derive_is_enum_variant = "0.1.1"
 failure = "0.1.3"
 http = "0.1.13"
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Determine the best encoding possible from an Accept-Encoding HTTP header.
 ## Examples
 __Basic usage__
 ```rust
+use accept_encoding::Encoding;
 use failure::Error;
 use http::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING};
 
@@ -19,7 +20,7 @@ fn main () -> Result<(), failure::Error> {
   headers.insert(ACCEPT_ENCODING, HeaderValue::from_str("gzip, deflate, br")?);
 
   let encoding = accept_encoding::parse(&headers)?;
-  assert!(encoding.is_brotli());
+  assert_eq!(encoding, Some(Encoding::Gzip));
   Ok(())
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub fn parse(headers: &HeaderMap) -> Result<Option<Encoding>> {
 ///
 /// Note that a result of `None` indicates there preference is expressed on which encoding to use.
 /// Either the `Accept-Encoding` header is not present, or `*` is set as the most preferred encoding.
-/// ## Example
+/// ## Examples
 /// ```rust
 /// # use failure::Error;
 /// use accept_encoding::Encoding;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,16 +41,18 @@ use http::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING};
 /// Encoding levels.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, is_enum_variant)]
 pub enum Encoding {
-    /// Gzip is the most preferred encoding present.
+    /// Gzip is the most preferred encoding.
     Gzip,
-    /// Deflate is the most preferred encoding present.
+    /// Deflate is the most preferred encoding.
     Deflate,
-    /// Brotli is the most preferred encoding present.
+    /// Brotli is the most preferred encoding.
     Brotli,
+    /// Zstd is the most preferred encoding.
+    Zstd,
     /// No encoding is preferred.
     Identity,
     /// No preference is expressed on which encoding to use. Either the `Accept-Encoding` header is not present, or `*` is set as the most preferred encoding.
-    None,
+    Any,
 }
 
 impl Encoding {
@@ -60,63 +62,100 @@ impl Encoding {
             "gzip" => Ok(Encoding::Gzip),
             "deflate" => Ok(Encoding::Deflate),
             "br" => Ok(Encoding::Brotli),
+            "zstd" => Ok(Encoding::Zstd),
             "identity" => Ok(Encoding::Identity),
-            "*" => Ok(Encoding::None),
+            "*" => Ok(Encoding::Any),
             _ => Err(ErrorKind::UnknownEncoding)?,
         }
     }
 
     /// Converts the encoding into its' corresponding header value.
     ///
-    /// Note that [`Encoding::None`] will return a HeaderValue with the content `*`.
+    /// Note that [`Encoding::Any`] will return a HeaderValue with the content `*`.
     /// This is likely not what you want if you are using this to generate the `Content-Encoding` header to be included in an encoded response.
     pub fn to_header_value(self) -> HeaderValue {
         match self {
             Encoding::Gzip => HeaderValue::from_str("gzip").unwrap(),
             Encoding::Deflate => HeaderValue::from_str("deflate").unwrap(),
             Encoding::Brotli => HeaderValue::from_str("br").unwrap(),
+            Encoding::Zstd => HeaderValue::from_str("zstd").unwrap(),
             Encoding::Identity => HeaderValue::from_str("identity").unwrap(),
-            Encoding::None => HeaderValue::from_str("*").unwrap(),
+            Encoding::Any => HeaderValue::from_str("*").unwrap(),
         }
     }
 }
 
-/// Parse a set of HTTP headers into an `Encoding`.
+/// Parse a set of HTTP headers into a single `Encoding` that the client prefers.
+///
+/// If you're looking for an easy way to determine the best encoding for the client and support every [`Encoding`] listed, this is likely what you want.
 pub fn parse(headers: &HeaderMap) -> Result<Encoding> {
-    let mut preferred_encoding = Encoding::None;
+    let mut preferred_encoding = Encoding::Any;
     let mut max_qval = 0.0;
 
-    for header_value in headers.get_all(ACCEPT_ENCODING).iter() {
-        let header_value = header_value.to_str().context(ErrorKind::InvalidEncoding)?;
-        for v in header_value.split(',').map(str::trim) {
-            let mut v = v.splitn(2, ";q=");
-            let encoding = v.next().unwrap();
-
-            match Encoding::parse(encoding) {
-                Ok(encoding) => {
-                    if let Some(qval) = v.next() {
-                        let qval = match qval.parse::<f32>() {
-                            Ok(f) => f,
-                            Err(_) => return Err(ErrorKind::InvalidEncoding)?,
-                        };
-                        if (qval - 1.0f32).abs() < 0.01 {
-                            preferred_encoding = encoding;
-                            break;
-                        } else if qval > 1.0 {
-                            return Err(ErrorKind::InvalidEncoding)?; // q-values over 1 are unacceptable
-                        } else if qval > max_qval {
-                            preferred_encoding = encoding;
-                            max_qval = qval;
-                        }
-                    } else {
-                        preferred_encoding = encoding;
-                        break;
-                    }
-                }
-                Err(_) => continue, // ignore unknown encodings for now
-            }
+    for (encoding, qval) in encodings(headers)? {
+        if (qval - 1.0f32).abs() < 0.01 {
+            preferred_encoding = encoding;
+            break;
+        } else if qval > max_qval {
+            preferred_encoding = encoding;
+            max_qval = qval;
         }
     }
 
     Ok(preferred_encoding)
+}
+
+/// Parse a set of HTTP headers into a vector containing tuples of encodings and their corresponding q-values.
+///
+/// If you're looking for more fine-grained control over what encoding to choose for the client, or if you don't support every [`Encoding`] listed, this is likely what you want.
+/// ## Example
+/// ```rust
+/// # use failure::Error;
+/// use accept_encoding::Encoding;
+/// use http::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING};
+///
+/// # fn main () -> Result<(), failure::Error> {
+/// let mut headers = HeaderMap::new();
+/// headers.insert(ACCEPT_ENCODING, HeaderValue::from_str("zstd;q=1.0, deflate;q=0.8, br;q=0.9")?);
+///
+/// let encodings = accept_encoding::encodings(&headers)?;
+/// for (encoding, qval) in encodings {
+///     println!("{:?} {}", encoding, qval);
+/// }
+/// # Ok(())}
+/// ```
+pub fn encodings(headers: &HeaderMap) -> Result<Vec<(Encoding, f32)>> {
+    headers
+        .get_all(ACCEPT_ENCODING)
+        .iter()
+        .map(|hval| {
+            hval.to_str()
+                .context(ErrorKind::InvalidEncoding)
+                .map_err(std::convert::Into::into)
+        })
+        .collect::<Result<Vec<&str>>>()?
+        .iter()
+        .flat_map(|s| s.split(',').map(str::trim))
+        .filter_map(|v| {
+            let mut v = v.splitn(2, ";q=");
+            let encoding = match Encoding::parse(v.next().unwrap()) {
+                Ok(encoding) => encoding,
+                Err(_) => return None, // ignore unknown encodings
+            };
+            let qval = if let Some(qval) = v.next() {
+                let qval = match qval.parse::<f32>() {
+                    Ok(f) => f,
+                    Err(_) => return Some(Err(ErrorKind::InvalidEncoding)),
+                };
+                if qval > 1.0 {
+                    return Some(Err(ErrorKind::InvalidEncoding)); // q-values over 1 are unacceptable
+                }
+                qval
+            } else {
+                1.0f32
+            };
+            Some(Ok((encoding, qval)))
+        })
+        .map(|v| v.map_err(std::convert::Into::into))
+        .collect::<Result<Vec<(Encoding, f32)>>>()
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -10,7 +10,7 @@ fn single_encoding() -> Result<(), Error> {
     let mut headers = HeaderMap::new();
     headers.insert(ACCEPT_ENCODING, HeaderValue::from_str("gzip")?);
 
-    let encoding = accept_encoding::parse(&headers)?.expect("Something went wrong");
+    let encoding = accept_encoding::parse(&headers)?.unwrap();
     assert_eq!(encoding, Encoding::Gzip);
 
     Ok(())
@@ -21,7 +21,7 @@ fn multiple_encodings() -> Result<(), Error> {
     let mut headers = HeaderMap::new();
     headers.insert(ACCEPT_ENCODING, HeaderValue::from_str("gzip, deflate, br")?);
 
-    let encoding = accept_encoding::parse(&headers)?.expect("Something went wrong");
+    let encoding = accept_encoding::parse(&headers)?.unwrap();
     assert_eq!(encoding, Encoding::Gzip);
 
     Ok(())
@@ -32,7 +32,7 @@ fn single_encoding_with_qval() -> Result<(), Error> {
     let mut headers = HeaderMap::new();
     headers.insert(ACCEPT_ENCODING, HeaderValue::from_str("deflate;q=1.0")?);
 
-    let encoding = accept_encoding::parse(&headers)?.expect("Something went wrong");
+    let encoding = accept_encoding::parse(&headers)?.unwrap();
     assert_eq!(encoding, Encoding::Deflate);
 
     Ok(())
@@ -46,7 +46,7 @@ fn multiple_encodings_with_qval_1() -> Result<(), Error> {
         HeaderValue::from_str("deflate, gzip;q=1.0, *;q=0.5")?,
     );
 
-    let encoding = accept_encoding::parse(&headers)?.expect("Something went wrong");
+    let encoding = accept_encoding::parse(&headers)?.unwrap();
     assert_eq!(encoding, Encoding::Deflate);
 
     Ok(())
@@ -60,7 +60,7 @@ fn multiple_encodings_with_qval_2() -> Result<(), Error> {
         HeaderValue::from_str("gzip;q=0.5, deflate;q=1.0, *;q=0.5")?,
     );
 
-    let encoding = accept_encoding::parse(&headers)?.expect("Something went wrong");
+    let encoding = accept_encoding::parse(&headers)?.unwrap();
     assert_eq!(encoding, Encoding::Deflate);
 
     Ok(())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -74,7 +74,40 @@ fn multiple_encodings_with_qval_3() -> Result<(), Error> {
     );
 
     let encoding = accept_encoding::parse(&headers)?;
-    assert!(encoding.is_none());
+    assert!(encoding.is_any());
 
+    Ok(())
+}
+
+#[test]
+fn list_encodings() -> Result<(), Error> {
+    use accept_encoding::Encoding;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        ACCEPT_ENCODING,
+        HeaderValue::from_str("zstd;q=1.0, deflate;q=0.8, br;q=0.9")?,
+    );
+
+    let encodings = accept_encoding::encodings(&headers)?;
+    assert_eq!(encodings[0], (Encoding::Zstd, 1.0));
+    assert_eq!(encodings[1], (Encoding::Deflate, 0.8));
+    assert_eq!(encodings[2], (Encoding::Brotli, 0.9));
+    Ok(())
+}
+
+#[test]
+fn list_encodings_ignore_unknown() -> Result<(), Error> {
+    use accept_encoding::Encoding;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        ACCEPT_ENCODING,
+        HeaderValue::from_str("zstd;q=1.0, unknown;q=0.8, br;q=0.9")?,
+    );
+
+    let encodings = accept_encoding::encodings(&headers)?;
+    assert_eq!(encodings[0], (Encoding::Zstd, 1.0));
+    assert_eq!(encodings[1], (Encoding::Brotli, 0.9));
     Ok(())
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,8 @@
 extern crate accept_encoding;
 extern crate failure;
 
-use failure::Error;
 use accept_encoding::Encoding;
+use failure::Error;
 use http::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING};
 
 #[test]


### PR DESCRIPTION
<!-- Provide a general summary of the changes in the title above -->
## Changes
This PR adds more features and breaking changes:
- Adds Zstd as an encoding
- Adds a function `encodings` that returns a Vec consisting of tuples containing encodings and their corresponding q-values. This should be helpful for some particular use cases.
- Removes `Encoding::None`. `parse` and `encodings` now return types `Option<Encoding>`, where an Option type of `None` indicates that there is no preference in particular for the given `Accept-Encoding` header(s).
- Removes the `derive_is_enum_variant` crate. I'm... not a huge fan of including it in this crate. Removing it also reduces the overall footprint of this crate.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->
This comes following my previous comment here: https://github.com/rustasync/accept-encoding/pull/1#issuecomment-491260667

Further changes were also made following the suggestions here: https://github.com/rustasync/tide/pull/194#issuecomment-491677536

## Semver Changes
<!-- Which semantic version change would you recommend? -->
More features and breaking changes! Likely still bump the minor version if it hasn't been already (0.2).
