### PR TITLE
Upgrade http crate to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accept-encoding"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-net-web/accept-encoding"
 documentation = "https://docs.rs/accept-encoding"
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1.3"
-http = "0.1.13"
+http = "0.2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** 🙋

<!-- Provide a general summary of the changes in the title above -->
Simply upgrades the http crate to 0.2. This is useful since most crates depending on http, that are still being updated, also upgraded.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Semver Changes
Since this is still tagged alpha, I'd suggest incrementing the alpha version.
